### PR TITLE
feat: add GcpLockFactory class, option to override blob name

### DIFF
--- a/src/main/java/GcpLockFactory.java
+++ b/src/main/java/GcpLockFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.util.concurrent.TimeUnit;
+
+public class GcpLockFactory {
+  private final String bucketName;
+  private final Storage storage = StorageOptions.getDefaultInstance().getService();
+
+  public GcpLockFactory(String bucket) {
+    this.bucketName = bucket;
+  }
+
+  public GcpLock createLock(String blob, long timeout, TimeUnit unit) throws InterruptedException {
+    return new GcpLock(storage, bucketName, blob, timeout, unit);
+  }
+}

--- a/src/test/java/GcpLockTest.java
+++ b/src/test/java/GcpLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Google Inc.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@
 import java.util.concurrent.TimeUnit;
 
 public class GcpLockTest {
+    private static String LOCK_NAME = "lock";
 
     public static void main(String[] args) {
+        // testLock("swast-scratch", 5);
         testLock("my-test-bucket-nnene", 5);
     }
 
@@ -31,10 +33,12 @@ public class GcpLockTest {
          * @param timeout number of seconds to attempt to lock/unlock resource
          */
 
-        try (GcpLock gcpLock1 = new GcpLock(bucketName, timeout)) {
+        GcpLockFactory lockFactory = new GcpLockFactory(bucketName);
+
+        try (GcpLock gcpLock1 = lockFactory.createLock(LOCK_NAME, timeout, TimeUnit.SECONDS)) {
             TimeUnit.SECONDS.sleep(3); // Do work
             // Following requests for locking should be time out since resource is still locked
-            try (GcpLock gcpLock2 = new GcpLock(bucketName, timeout)) {
+            try (GcpLock gcpLock2 = lockFactory.createLock(LOCK_NAME, timeout, TimeUnit.SECONDS)) {
                 TimeUnit.SECONDS.sleep(3); // Do work
                 System.err.println("Test lock failed.");
             } catch (Exception e) {


### PR DESCRIPTION
A factory class allows there to be one Storage client per program/thread
rather than one client per lock.

It will be necessary to create many different locks with the same
factory (and bucket), so allow the blob name to be overridden.